### PR TITLE
Update slang configuration

### DIFF
--- a/slang.conf
+++ b/slang.conf
@@ -1,3 +1,3 @@
-./src/
+src/uvm_pkg.sv
 -I ./src/
---error-limit 1000
+-Wno-missing-top


### PR DESCRIPTION
Only pass `src/uvm_pkg.sv` to slang, and let that file refer to the rest. Fixes Linty-Services/linty-slang#98